### PR TITLE
Add comprehensive bilingual documentation (English/Korean)

### DIFF
--- a/CLAUDE_CODE_완전가이드.md
+++ b/CLAUDE_CODE_완전가이드.md
@@ -1,0 +1,622 @@
+# Claude Code 완전 사용 가이드
+
+## 개요
+
+Claude Code는 개발자 워크플로우에 직접 통합되는 터미널 기반 AI 코딩 어시스턴트입니다. 이 가이드는 연구와 실제 사례를 바탕으로 한 포괄적인 사용 패턴, 폴더 구조, 고급 설정을 다룹니다.
+
+## 목차
+
+1. [설치 및 설정](#설치-및-설정)
+2. [폴더 구조 패턴](#폴더-구조-패턴)  
+3. [설정 예제](#설정-예제)
+4. [고급 기능](#고급-기능)
+5. [모범 사례](#모범-사례)
+6. [실제 예제](#실제-예제)
+
+## 설치 및 설정
+
+### 빠른 설치
+```bash
+# Claude Code 전역 설치
+npm install -g @anthropic-ai/claude-code
+
+# 프로젝트에서 초기화
+claude-code init
+```
+
+### 필수 조건
+- Node.js 18+
+- Git 저장소 (권장)
+- Anthropic, AWS Bedrock, 또는 Google Vertex AI의 API 키
+
+## 폴더 구조 패턴
+
+### 기본 프로젝트 구조
+최소한의 Claude Code 설정은 프로젝트 루트에 `.claude` 폴더가 필요합니다:
+
+```
+project-root/
+├── .claude/
+│   ├── settings.json          # 메인 설정
+│   ├── settings.local.json    # 개인 재정의 (gitignore)
+│   └── hooks/                 # 커스텀 자동화 스크립트
+│       ├── format-and-lint.sh
+│       └── pre-commit-check.sh
+├── src/
+├── tests/
+└── README.md
+```
+
+### 고급 프로젝트 구조  
+여러 환경과 전문화된 에이전트가 있는 복잡한 프로젝트의 경우:
+
+```
+enterprise-project/
+├── .claude/
+│   ├── settings.json          # 팀 공유 설정
+│   ├── settings.local.json    # 개인 개발 설정
+│   ├── settings.prod.json     # 프로덕션 전용 설정
+│   ├── agents/                # 커스텀 에이전트 정의
+│   │   ├── backend-architect.md
+│   │   ├── frontend-specialist.md
+│   │   └── devops-engineer.md
+│   ├── hooks/                 # 자동화 스크립트
+│   │   ├── pre-commit-checks.sh
+│   │   ├── comprehensive-check.sh
+│   │   └── deployment-validation.sh
+│   └── mcp/                   # MCP 서버 설정
+│       ├── github.json
+│       ├── monitoring.json
+│       └── database.json
+├── services/                  # 마이크로서비스용
+│   ├── auth-service/
+│   ├── user-service/
+│   └── notification-service/
+├── frontend/
+├── infrastructure/
+│   ├── kubernetes/
+│   ├── terraform/
+│   └── docker/
+└── docs/
+```
+
+### 마이크로서비스 아키텍처 구조
+여러 서비스가 있는 분산 시스템의 경우:
+
+```
+microservices-project/
+├── .claude/
+│   ├── settings.json          # 글로벌 마이크로서비스 설정
+│   ├── agents/
+│   │   ├── microservice-architect.md
+│   │   ├── kubernetes-specialist.md
+│   │   └── api-gateway-engineer.md
+│   └── hooks/
+│       ├── microservice-validation.sh
+│       └── container-security-check.sh
+├── services/
+│   ├── auth-service/
+│   │   ├── .claude/settings.json    # 서비스별 설정
+│   │   ├── Dockerfile
+│   │   ├── k8s/
+│   │   └── src/
+│   ├── user-service/
+│   └── payment-service/
+├── api-gateway/
+├── monitoring/
+│   ├── prometheus/
+│   ├── grafana/
+│   └── jaeger/
+└── k8s/                       # 공유 Kubernetes 매니페스트
+    ├── namespaces/
+    ├── ingress/
+    └── monitoring/
+```
+
+## 설정 예제
+
+### 1. 기본 설정 (`settings.json`)
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash",
+      "Read", 
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '🔍 사전 검사: 수정 전 검증 중...'",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/format-and-lint.sh", 
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  },
+  "model": "claude-3-5-sonnet-20241022",
+  "environment": {
+    "NODE_ENV": "development",
+    "PROJECT_TYPE": "fullstack"
+  }
+}
+```
+
+### 2. 에이전트가 있는 고급 설정
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash", "Read", "Write", "Edit", "MultiEdit", 
+      "Glob", "Grep", "WebFetch", "Task"
+    ]
+  },
+  "subagents": {
+    "backend-architect": {
+      "name": "백엔드 아키텍트",
+      "description": "백엔드 아키텍처, API 설계, 데이터베이스 최적화 전문가",
+      "model": "claude-3-5-sonnet-20241022",
+      "instructions": "확장 가능한 시스템 설계, API 아키텍처, 데이터베이스 최적화, 성능에 중점을 둡니다. 항상 보안, 유지보수성, 확장성을 고려하세요."
+    },
+    "frontend-specialist": {
+      "name": "프론트엔드 전문가",
+      "description": "React, TypeScript, UI/UX를 활용한 모던 프론트엔드 개발 전문가", 
+      "model": "claude-3-5-sonnet-20241022",
+      "instructions": "모던 React 패턴, TypeScript 모범 사례, 반응형 디자인, 접근성, 성능 최적화에 중점을 둡니다."
+    }
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'if [ -f \"Makefile\" ] && make -n check >/dev/null 2>&1 && ! make check >/dev/null 2>&1; then echo \"❌ 파일 수정 불가: make check가 실패 중입니다.\" >&2; exit 2; fi'",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/comprehensive-check.sh",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  },
+  "model": "claude-3-5-sonnet-20241022",
+  "environment": {
+    "NODE_ENV": "development",
+    "PYTHON_ENV": "development",
+    "PROJECT_TYPE": "fullstack",
+    "ENABLE_DEBUG": "true"
+  },
+  "tools": {
+    "disabled": [],
+    "custom": {
+      "project-stats": {
+        "command": "find . -name '*.ts' -o -name '*.js' -o -name '*.py' | wc -l",
+        "description": "프로젝트의 총 코드 파일 수 계산"
+      }
+    }
+  }
+}
+```
+
+### 3. 마이크로서비스 설정
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash", "Read", "Write", "Edit", "MultiEdit", "Glob", "Grep", "WebFetch", "Task"]
+  },
+  "agents": [
+    {
+      "name": "microservice-architect",
+      "description": "마이크로서비스 아키텍처, 서비스 메시, API 게이트웨이 설계, 분산 시스템 패턴 전문가",
+      "instructions": "분산 시스템을 전문으로 합니다. 서비스 분해, 서비스 간 통신, 데이터 일관성 패턴, 서킷 브레이커, 관찰성에 중점을 둡니다.",
+      "model": "claude-3-5-sonnet-20241022"
+    },
+    {
+      "name": "kubernetes-specialist",
+      "description": "Kubernetes, 컨테이너 오케스트레이션, 서비스 메시, 클라우드 네이티브 배포 패턴 전문가", 
+      "instructions": "컨테이너 오케스트레이션, 서비스 디스커버리, 로드 밸런싱, 자동 스케일링, 모니터링, 클라우드 네이티브 배포 전략에 중점을 둡니다.",
+      "model": "claude-3-5-sonnet-20241022"
+    }
+  ],
+  "mcp": {
+    "servers": {
+      "kubernetes": {
+        "command": "kubectl-mcp-server",
+        "args": ["--kubeconfig", "~/.kube/config"]
+      },
+      "docker-compose": {
+        "command": "docker-compose-mcp-server",
+        "args": ["--file", "docker-compose.yml"]
+      }
+    }
+  }
+}
+```
+
+## 고급 기능
+
+### 1. 모델 컨텍스트 프로토콜 (MCP) 통합
+
+Claude Code는 외부 도구 및 데이터 소스와의 통합을 위한 MCP를 지원합니다:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "github": {
+        "command": "mcp-server-github",
+        "args": ["--auth-token", "${GITHUB_TOKEN}"]
+      },
+      "sentry": {
+        "command": "mcp-server-sentry", 
+        "args": ["--org", "my-org", "--auth-token", "${SENTRY_TOKEN}"]
+      },
+      "database": {
+        "command": "mcp-server-postgres",
+        "args": ["--connection-string", "${DATABASE_URL}"]
+      }
+    }
+  }
+}
+```
+
+### 2. 커스텀 훅 시스템
+
+훅은 도구 사용의 다양한 단계에서 자동화를 허용합니다:
+
+**사전 도구 사용 훅**: Claude Code가 도구를 실행하기 전에 실행
+- 코드 품질 검증
+- 보안 검사
+- 환경 확인
+
+**사후 도구 사용 훅**: Claude Code가 도구를 실행한 후에 실행  
+- 자동 포맷팅
+- 테스팅
+- 빌드 검증
+- 배포 검사
+
+### 3. 전문화된 에이전트
+
+에이전트는 특정 작업에 최적화된 Claude의 전문화된 인스턴스입니다:
+
+```markdown
+---
+name: backend-typescript-architect
+description: Bun 런타임을 사용한 TypeScript 백엔드 개발 전문가
+color: red
+---
+
+당신은 다음 분야의 깊은 전문 지식을 갖춘 시니어 백엔드 TypeScript 아키텍트입니다:
+- 백엔드 시스템을 위한 고급 TypeScript 패턴 및 모범 사례
+- Bun 런타임 최적화 및 생태계 숙련도  
+- RESTful API 설계 및 GraphQL 구현
+- 데이터베이스 설계, 최적화 및 ORM 사용
+- 마이크로서비스 아키텍처 및 분산 시스템
+
+개발 철학:
+- 전략적 주석으로 자체 문서화 코드 작성
+- 타입 안전성을 우선시하고 TypeScript의 고급 기능 활용
+- 처음부터 유지보수성, 확장성, 성능을 위한 설계
+- SOLID 원칙 및 클린 아키텍처 패턴 준수
+```
+
+### 4. 환경 관리
+
+Claude Code는 계층적 구성을 지원합니다:
+
+1. **기업/조직 수준**: 글로벌 정책
+2. **사용자 수준** (`~/.claude/settings.json`): 개인 설정
+3. **프로젝트 수준** (`.claude/settings.json`): 팀 공유 설정
+4. **로컬 수준** (`.claude/settings.local.json`): 개인 프로젝트 재정의
+
+## 모범 사례
+
+### 1. 보안 모범 사례
+
+```json
+{
+  "permissions": {
+    "allow": ["Read", "Glob", "Grep"],
+    "deny": ["Bash", "Write", "Edit"]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/security-scan.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 2. 개발 워크플로우 통합
+
+**TDD 워크플로우 예제**:
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command", 
+            "command": "bash -c 'if ! make test >/dev/null 2>&1; then echo \"❌ 테스트 실패 - 코드 수정 전 수정하세요\" >&2; exit 1; fi'",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "make test && make format && make lint",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 3. 다중 언어 프로젝트 지원
+
+```bash
+#!/bin/bash
+# .claude/hooks/comprehensive-check.sh
+
+# Node.js/TypeScript
+if [ -f "package.json" ]; then
+    npm run type-check
+    npm run lint
+    npm run test
+fi
+
+# Python  
+if [ -f "pyproject.toml" ]; then
+    uv run ruff format .
+    uv run ruff check .
+    uv run mypy .
+    uv run pytest
+fi
+
+# Rust
+if [ -f "Cargo.toml" ]; then
+    cargo fmt
+    cargo clippy
+    cargo test
+fi
+
+# Go
+if [ -f "go.mod" ]; then
+    go fmt ./...
+    go vet ./...
+    go test ./...
+fi
+```
+
+## 실제 예제
+
+### 예제 1: 기본 웹 애플리케이션 설정
+
+```bash
+# 프로젝트 초기화
+mkdir my-web-app && cd my-web-app
+git init
+
+# 기본 Claude Code 설정 생성
+mkdir -p .claude/hooks
+
+# 기본 설정
+cat > .claude/settings.json << 'EOF'
+{
+  "permissions": {
+    "allow": ["Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/format-and-lint.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+
+# 포맷 훅 생성
+cat > .claude/hooks/format-and-lint.sh << 'EOF'
+#!/bin/bash
+if [ -f "package.json" ]; then
+    npm run format 2>/dev/null || true
+    npm run lint -- --fix 2>/dev/null || true
+fi
+EOF
+
+chmod +x .claude/hooks/format-and-lint.sh
+```
+
+### 예제 2: 마이크로서비스 프로젝트 설정
+
+```bash
+# 마이크로서비스 프로젝트 초기화
+mkdir microservices-app && cd microservices-app
+git init
+
+# 고급 설정 생성
+mkdir -p .claude/{hooks,agents}
+
+# 마이크로서비스 에이전트가 있는 고급 설정
+cat > .claude/settings.json << 'EOF'
+{
+  "permissions": {
+    "allow": ["Bash", "Read", "Write", "Edit", "MultiEdit", "Glob", "Grep", "WebFetch", "Task"]
+  },
+  "agents": [
+    {
+      "name": "microservice-architect",
+      "description": "마이크로서비스 아키텍처 및 분산 시스템 전문가",
+      "model": "claude-3-5-sonnet-20241022"
+    }
+  ],
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/microservice-validation.sh",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+
+# 프로젝트 구조 생성
+mkdir -p {services/{auth,user,payment},api-gateway,monitoring,k8s}
+```
+
+### 예제 3: TDD를 사용한 Python/FastAPI 프로젝트
+
+```bash
+# uv를 사용한 Python 프로젝트 초기화
+mkdir fastapi-project && cd fastapi-project
+git init
+
+# TDD 워크플로우를 위한 Claude Code 설정 생성
+mkdir -p .claude/hooks
+
+cat > .claude/settings.json << 'EOF'
+{
+  "permissions": {
+    "allow": ["Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'if [ -f \"Makefile\" ] && ! make check >/dev/null 2>&1; then echo \"❌ 실패한 검사를 먼저 수정하세요\" >&2; exit 1; fi'",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "make format && make check && make test",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  },
+  "environment": {
+    "PYTHON_ENV": "development"
+  }
+}
+EOF
+
+# uv 프로젝트 초기화
+uv init
+uv add fastapi uvicorn pytest ruff mypy
+
+# TDD 워크플로우를 위한 Makefile 생성
+cat > Makefile << 'EOF'
+.PHONY: format check test run
+
+format:
+	uv run ruff format .
+
+check:
+	uv run ruff check .
+	uv run mypy .
+
+test:
+	uv run pytest -v
+
+run:
+	uv run uvicorn app.main:app --reload
+EOF
+```
+
+## 요약
+
+Claude Code는 다음을 통해 강력한 커스터마이제이션을 제공합니다:
+
+1. **계층적 구성**: 기업 → 사용자 → 프로젝트 → 로컬 설정
+2. **커스텀 훅**: 사전/사후 도구 실행 시 자동화
+3. **전문화된 에이전트**: 도메인별 AI 어시스턴트  
+4. **MCP 통합**: 외부 도구 및 데이터 소스 연결
+5. **다중 언어 지원**: 기술 스택 전반의 통합 워크플로우
+
+효과적인 Claude Code 사용의 핵심은:
+- 기본 설정으로 시작하여 반복 개선
+- 자동화 및 품질 게이트를 위한 훅 사용
+- 전문화된 작업을 위한 에이전트 활용
+- 기존 개발 워크플로우와 통합
+- 전반적으로 보안 및 모범 사례 유지
+
+이러한 포괄적인 설정을 통해 팀은 코드 품질을 유지하고, 반복 작업을 자동화하며, 복잡한 다중 서비스 아키텍처 전반에서 AI 지원을 효과적으로 활용할 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,137 @@
+# Claude Code Usage Examples / Claude Code 사용 예제
+
+[English](#english) | [한국어](#한국어)
+
+---
+
+## English
+
+This repository contains comprehensive Claude Code configuration examples and documentation for various project types and development scenarios.
+
+### 📁 Repository Structure
+
+- **CLAUDE.md**: Repository-specific guidance for Claude Code instances
+- **CLAUDE_CODE_COMPLETE_GUIDE.md**: Complete usage guide with installation, configuration, and best practices
+- **claude-code-examples/**: Seven complete configuration examples with executable hooks
+- **CLAUDE_CODE_완전가이드.md**: Korean version of the complete guide
+
+### 🚀 Featured Examples
+
+**7 Complete Configuration Examples**:
+
+1. **Basic Project**: Simple web applications with formatting/linting
+2. **Advanced Project**: Complex fullstack with subagents and comprehensive validation  
+3. **Microservices Project**: Distributed systems with container orchestration
+4. **Enterprise Security Project**: High-security environments with compliance validation
+5. **AI Research Project**: ML research with experiment tracking and MCP integration
+6. **Startup MVP Project**: Rapid development with modern startup stack
+7. **Open Source Project**: OSS maintenance with community workflows
+
+### 🔧 Key Features Covered
+
+- **Hierarchical Configuration**: Enterprise → User → Project → Local settings
+- **Custom Hooks**: Pre/post-tool automation with 15+ executable scripts
+- **Specialized Agents**: Domain-specific AI assistants for various roles
+- **MCP Integration**: External tool connections (GitHub, W&B, Supabase, etc.)
+- **Multi-language Support**: Node.js, Python, Rust, Go with appropriate tooling
+- **Security Validation**: Advanced prompt filtering and compliance checking
+- **Advanced Patterns**: TDD integration, experiment tracking, deployment automation
+
+### 📖 Quick Start
+
+1. Choose an appropriate example from `claude-code-examples/`
+2. Copy the `.claude/` configuration to your project
+3. Customize `settings.json` for your specific needs
+4. Make hook scripts executable: `chmod +x .claude/hooks/*.sh`
+5. Start using Claude Code with your configured setup
+
+### 🏗️ Architecture Examples
+
+From simple projects to complex distributed systems:
+- **Basic**: Single service with formatting hooks
+- **Enterprise**: Multi-agent security-focused development
+- **Research**: ML experiment tracking with reproducibility
+- **Microservices**: Container orchestration with service mesh validation
+
+---
+
+## 한국어
+
+다양한 프로젝트 유형과 개발 시나리오를 위한 포괄적인 Claude Code 설정 예제와 문서를 포함한 저장소입니다.
+
+### 📁 저장소 구조
+
+- **CLAUDE.md**: Claude Code 인스턴스를 위한 저장소별 가이드
+- **CLAUDE_CODE_COMPLETE_GUIDE.md**: 설치, 설정, 모범 사례가 포함된 완전 사용 가이드 (영문)
+- **claude-code-examples/**: 실행 가능한 훅이 있는 7개의 완전한 설정 예제
+- **CLAUDE_CODE_완전가이드.md**: 완전 가이드 한국어 버전
+
+### 🚀 주요 예제
+
+**7개의 완전한 설정 예제**:
+
+1. **기본 프로젝트**: 포맷팅/린팅이 포함된 간단한 웹 애플리케이션
+2. **고급 프로젝트**: 서브에이전트와 포괄적 검증이 있는 복잡한 풀스택  
+3. **마이크로서비스 프로젝트**: 컨테이너 오케스트레이션이 있는 분산 시스템
+4. **기업 보안 프로젝트**: 컴플라이언스 검증이 있는 고보안 환경
+5. **AI 연구 프로젝트**: 실험 추적 및 MCP 통합이 있는 ML 연구
+6. **스타트업 MVP 프로젝트**: 모던 스타트업 스택을 활용한 빠른 개발
+7. **오픈소스 프로젝트**: 커뮤니티 워크플로우가 있는 OSS 유지보수
+
+### 🔧 다루는 주요 기능
+
+- **계층적 설정**: 기업 → 사용자 → 프로젝트 → 로컬 설정
+- **커스텀 훅**: 15개 이상의 실행 가능한 스크립트로 사전/사후 도구 자동화
+- **전문화된 에이전트**: 다양한 역할을 위한 도메인별 AI 어시스턴트
+- **MCP 통합**: 외부 도구 연결 (GitHub, W&B, Supabase 등)
+- **다중 언어 지원**: 적절한 도구가 있는 Node.js, Python, Rust, Go
+- **보안 검증**: 고급 프롬프트 필터링 및 컴플라이언스 확인
+- **고급 패턴**: TDD 통합, 실험 추적, 배포 자동화
+
+### 📖 빠른 시작
+
+1. `claude-code-examples/`에서 적절한 예제 선택
+2. `.claude/` 설정을 프로젝트에 복사
+3. 특정 요구사항에 맞게 `settings.json` 커스터마이징
+4. 훅 스크립트를 실행 가능하게 만들기: `chmod +x .claude/hooks/*.sh`
+5. 설정된 설정으로 Claude Code 사용 시작
+
+### 🏗️ 아키텍처 예제
+
+간단한 프로젝트부터 복잡한 분산 시스템까지:
+- **기본**: 포맷팅 훅이 있는 단일 서비스
+- **기업**: 보안 중심 개발을 위한 다중 에이전트
+- **연구**: 재현성이 있는 ML 실험 추적
+- **마이크로서비스**: 서비스 메시 검증이 있는 컨테이너 오케스트레이션
+
+---
+
+## Documentation / 문서
+
+### English Documentation
+- [Complete Guide](./CLAUDE_CODE_COMPLETE_GUIDE.md) - Comprehensive usage guide with all features
+- [Examples README](./claude-code-examples/README.md) - Detailed explanation of all configuration examples
+
+### Korean Documentation / 한국어 문서
+- [완전 가이드](./CLAUDE_CODE_완전가이드.md) - 모든 기능을 포함한 포괄적 사용 가이드
+- [예제 README](./claude-code-examples/README.md) - 모든 설정 예제의 상세 설명
+
+## Contributing / 기여
+
+This repository demonstrates various Claude Code usage patterns. Feel free to:
+- Add new configuration examples
+- Improve existing hook scripts
+- Enhance documentation
+- Share your Claude Code setup patterns
+
+이 저장소는 다양한 Claude Code 사용 패턴을 보여줍니다. 자유롭게:
+- 새로운 설정 예제 추가
+- 기존 훅 스크립트 개선
+- 문서 향상
+- Claude Code 설정 패턴 공유
+
+## License / 라이센스
+
+MIT License - Feel free to use these examples in your projects.
+
+MIT 라이센스 - 이 예제들을 자유롭게 프로젝트에서 사용하세요.

--- a/claude-code-examples/README.md
+++ b/claude-code-examples/README.md
@@ -1,4 +1,10 @@
-# Claude Code Configuration Examples
+# Claude Code Configuration Examples / Claude Code 설정 예제
+
+[English](#english) | [한국어](#한국어)
+
+---
+
+## English
 
 This directory contains comprehensive examples of Claude Code configurations for different project types and use cases.
 
@@ -194,3 +200,202 @@ Settings are applied in this order of precedence:
 ## Further Reading
 
 See `CLAUDE_CODE_COMPLETE_GUIDE.md` in the parent directory for comprehensive documentation on Claude Code usage patterns, advanced features, and integration strategies.
+
+---
+
+## 한국어
+
+이 디렉토리는 다양한 프로젝트 유형과 사용 사례를 위한 Claude Code 설정의 포괄적인 예제를 포함합니다.
+
+## 디렉토리 구조
+
+```
+claude-code-examples/
+├── basic-project/               # 간단한 웹 애플리케이션 설정
+│   └── .claude/
+│       ├── settings.json        # 기본 설정
+│       └── hooks/
+│           └── format-and-lint.sh
+├── advanced-project/            # 복잡한 풀스택 프로젝트
+│   └── .claude/
+│       ├── settings.json        # 서브에이전트가 있는 고급 설정
+│       └── hooks/
+│           └── comprehensive-check.sh
+├── microservices-project/       # 분산 시스템 설정
+│   └── .claude/
+│       ├── settings.json        # 마이크로서비스 전용 설정
+│       └── hooks/
+│           ├── microservice-validation.sh
+│           └── pre-commit-checks.sh
+├── enterprise-security-project/ # 고보안 기업 환경
+│   └── .claude/
+│       ├── settings.json        # 보안 중점 설정
+│       └── hooks/
+│           └── security-prompt-filter.py
+├── ai-research-project/         # ML/AI 연구 환경
+│   └── .claude/
+│       ├── settings.json        # MCP가 포함된 연구 중점 설정
+│       └── hooks/
+│           └── experiment-tracking.py
+├── startup-mvp-project/         # 빠른 MVP 개발
+│   └── .claude/
+│       ├── settings.json        # MVP 중점 설정
+│       └── hooks/
+│           └── rapid-feedback.sh
+└── open-source-project/         # OSS 프로젝트 관리
+    └── .claude/
+        ├── settings.json        # 커뮤니티 중점 설정
+        ├── commands/
+        │   └── create-issue-template.md
+        └── hooks/
+            └── contribution-standards.sh
+```
+
+## 예제 설정들
+
+### 1. 기본 프로젝트 (`basic-project/`)
+- **사용 사례**: 간단한 웹 애플리케이션, 소규모 팀
+- **기능**: 
+  - 기본 권한 및 훅
+  - 자동 포맷팅 및 린팅
+  - 간단한 오류 검사
+- **언어**: JavaScript/TypeScript, Python, Rust
+- **훅 스크립트**: format-and-lint.sh
+
+### 2. 고급 프로젝트 (`advanced-project/`)
+- **사용 사례**: 복잡한 풀스택 애플리케이션, 대규모 팀
+- **기능**:
+  - 전문화된 서브에이전트 (백엔드, 프론트엔드, 데브옵스)
+  - 포괄적인 사전/사후 도구 훅
+  - 광범위한 검증이 포함된 다중 언어 지원
+  - 보안 감사 및 타입 검사
+- **언어**: 고급 도구가 포함된 모든 주요 언어
+- **훅 스크립트**: comprehensive-check.sh
+
+### 3. 마이크로서비스 프로젝트 (`microservices-project/`)
+- **사용 사례**: 분산 시스템, 컨테이너 오케스트레이션
+- **기능**:
+  - 마이크로서비스 전용 에이전트
+  - Kubernetes 및 Docker 검증
+  - 서비스 메시 및 API 게이트웨이 설정
+  - 포괄적인 컨테이너 및 보안 검사
+- **기술**: Docker, Kubernetes, 서비스 메시
+- **훅 스크립트**: microservice-validation.sh, pre-commit-checks.sh
+
+### 4. 기업 보안 프로젝트 (`enterprise-security-project/`)
+- **사용 사례**: 고보안 기업 환경, 컴플라이언스 중심 개발
+- **기능**:
+  - 보안 우선 접근법으로 제한된 권한
+  - 고급 프롬프트 필터링 및 검증
+  - 포괄적인 감사 로깅
+  - 컴플라이언스 확인 및 위험 평가
+- **보안 중점**: 방어적 보안, 취약성 분석, 컴플라이언스 검증
+- **훅 스크립트**: security-prompt-filter.py, compliance-check.py, audit-logging.py
+
+### 5. AI 연구 프로젝트 (`ai-research-project/`)
+- **사용 사례**: 머신러닝 연구, 데이터 사이언스, 학술 환경
+- **기능**:
+  - ML 중점 에이전트 (연구자, 데이터 사이언티스트, 연구 엔지니어)
+  - 실험 추적 및 재현성
+  - 연구 도구와의 MCP 통합 (arXiv, W&B, HuggingFace)
+  - GPU 모니터링 및 컴퓨팅 리소스 관리
+- **연구 도구**: MLflow, W&B, arXiv, Kaggle, HuggingFace
+- **훅 스크립트**: experiment-tracking.py, context-enhancement.py, compute-monitoring.py
+
+### 6. 스타트업 MVP 프로젝트 (`startup-mvp-project/`)
+- **사용 사례**: 빠른 프로토타이핑, 스타트업 개발, 빠른 반복
+- **기능**:
+  - 제품 중심 에이전트 (PM, 풀스택 개발자, 성장 엔지니어)
+  - 빠른 피드백 및 배포 준비 상태 검사
+  - 모던 스타트업 스택 통합 (Vercel, Supabase, PostHog)
+  - 성능 및 전환 최적화
+- **스타트업 스택**: Vercel, Supabase, PostHog, Stripe
+- **훅 스크립트**: rapid-feedback.sh, deployment-ready-check.sh, mvp-validation.sh
+
+### 7. 오픈소스 프로젝트 (`open-source-project/`)
+- **사용 사례**: OSS 유지보수, 커뮤니티 관리, 공개 저장소
+- **기능**:
+  - 커뮤니티 중심 에이전트 (유지보수자, 문서 전문가, 커뮤니티 매니저)
+  - OSS 표준 검증 및 기여 워크플로우
+  - 라이선스 컴플라이언스 및 보안 스캐닝
+  - GitHub 통합 및 자동화된 워크플로우
+- **커뮤니티 도구**: GitHub Actions, semantic-release, license-checker
+- **훅 스크립트**: contribution-standards.sh, license-check.py, ci-cd-validation.sh
+- **커스텀 명령어**: create-issue-template.md
+
+## 훅 스크립트 설명
+
+### format-and-lint.sh (기본)
+- 프로젝트 유형 감지 (Node.js, Python, Rust)
+- 적절한 포맷터 실행 (Prettier, ruff, rustfmt)
+- 린팅 수정 적용 (ESLint, ruff, clippy)
+
+### comprehensive-check.sh (고급)  
+- 다중 언어 타입 검사 및 테스팅
+- 보안 감사
+- 성능 검증
+- Docker 빌드 확인
+- 완전한 CI/CD 파이프라인 시뮬레이션
+
+### microservice-validation.sh (마이크로서비스)
+- Dockerfile 및 Kubernetes 매니페스트 검증
+- 서비스 디스커버리 및 API 게이트웨이 검사
+- 헬스 체크 엔드포인트 확인
+- 관찰성 설정 검증
+- 보안 및 리소스 제한 검사
+
+### security-prompt-filter.py (기업 보안)
+- 보안 위험에 대한 고급 프롬프트 검증
+- 자격 증명 노출 감지
+- SQL/셸 인젝션 방지
+- 컴플라이언스 위반 검사
+- 포괄적인 감사 로깅
+
+### experiment-tracking.py (AI 연구)
+- 자동 실험 메타데이터 추적
+- Git 커밋 및 환경 캡처
+- ML 프레임워크 감지 및 통합
+- 재현성을 위한 파일 해싱
+- W&B 및 MLflow 통합
+
+### rapid-feedback.sh (스타트업 MVP)
+- 빠른 빌드 및 배포 검증
+- 번들 크기 최적화 검사
+- 필수 파일 확인
+- 환경 설정 검증
+- MVP 준비 상태 점수 매기기
+
+### contribution-standards.sh (오픈소스)
+- OSS 프로젝트 건강도 평가
+- 필수 파일 검증 (README, LICENSE 등)
+- Package.json 완성도 검사
+- CI/CD 워크플로우 검증
+- 커뮤니티 템플릿 확인
+
+## 사용법
+
+1. **설정 복사**: 적절한 예제를 프로젝트에 복사
+2. **설정 커스터마이징**: 특정 요구사항에 맞게 settings.json 수정
+3. **훅 업데이트**: 프로젝트 요구사항에 맞게 훅 스크립트 조정
+4. **권한 설정**: `chmod +x`로 훅 스크립트를 실행 가능하게 만들기
+
+## 설정 계층 구조
+
+설정은 다음 우선순위로 적용됩니다:
+1. 기업/조직 정책
+2. 사용자 설정 (`~/.claude/settings.json`)
+3. 프로젝트 설정 (`.claude/settings.json`)
+4. 로컬 재정의 (`.claude/settings.local.json`)
+
+## 모범 사례
+
+1. **간단하게 시작**: basic-project 설정으로 시작
+2. **점진적 반복**: 프로젝트가 성장함에 따라 복잡성 추가
+3. **훅 테스트**: 환경에서 훅 스크립트가 작동하는지 확인
+4. **변경사항 문서화**: 설정 변경사항으로 README 업데이트 유지
+5. **보안 우선**: 설정 파일에 민감한 정보 커밋 금지
+6. **버전 제어**: .claude/settings.json 커밋, settings.local.json 무시
+
+## 추가 읽기
+
+Claude Code 사용 패턴, 고급 기능, 통합 전략에 대한 포괄적인 문서는 상위 디렉토리의 `CLAUDE_CODE_완전가이드.md`를 참조하세요.


### PR DESCRIPTION
## New Documentation Added
- **README.md**: Bilingual project overview with navigation in both languages
- **CLAUDE_CODE_완전가이드.md**: Complete Korean translation of the comprehensive guide
- **claude-code-examples/README.md**: Enhanced with full Korean translations

## Features
- Full bilingual support with language navigation
- Comprehensive Korean translations of all 7 configuration examples
- Detailed Korean explanations of hook scripts and usage patterns
- Consistent terminology and professional Korean technical writing
- Cross-references between English and Korean documentation

## Documentation Structure
- English documentation: CLAUDE_CODE_COMPLETE_GUIDE.md + README.md
- Korean documentation: CLAUDE_CODE_완전가이드.md + README.md (bilingual)
- All examples now have detailed Korean descriptions and explanations

The repository now provides complete accessibility for both English and Korean-speaking developers, with comprehensive examples ranging from basic projects to enterprise-level configurations.

🤖 Generated with [Claude Code](https://claude.ai/code)